### PR TITLE
Add easy slew control to all MotorCollections

### DIFF
--- a/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
+++ b/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
@@ -10,6 +10,7 @@ import edu.wpi.first.wpilibj.SpeedControllerGroup;
 import frc.lib5k.components.motors.interfaces.ICurrentController;
 import frc.lib5k.components.motors.interfaces.IMotorCollection;
 import frc.lib5k.components.motors.interfaces.IMotorGroupSafety;
+import frc.lib5k.components.motors.interfaces.IRampRateController;
 import frc.lib5k.components.motors.interfaces.IVoltageOutputController;
 import frc.lib5k.components.motors.motorsensors.TalonEncoder;
 import frc.lib5k.components.sensors.EncoderBase;
@@ -25,7 +26,7 @@ import frc.lib5k.utils.telemetry.ComponentTelemetry;
  * SpeedControllerGroup
  */
 public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCollection, ICurrentController,
-        IEncoderProvider, IMotorGroupSafety, IVoltageOutputController, Loggable {
+        IEncoderProvider, IMotorGroupSafety, IVoltageOutputController, IRampRateController, Loggable {
     RobotLogger logger = RobotLogger.getInstance();
 
     /* Talon SRX Objects */
@@ -34,7 +35,7 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
 
     /* Locals */
     private String name;
-    private double output, currentThresh, currentHold;
+    private double output, currentThresh, currentHold, rampRate;
     private boolean inverted, voltageCompEnabled, currentLimited;
 
     /* Telemetry */
@@ -179,6 +180,29 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
     }
 
     @Override
+    public void setRampRate(double secondsToFull) {
+        rampRate = secondsToFull;
+
+    }
+
+    @Override
+    public double getRampRate() {
+        return rampRate;
+    }
+
+    @Override
+    public void enableRampRateLimiting(boolean enabled) {
+
+        // Handle TalonSRX configuration
+        if (enabled) {
+            master.configOpenloopRamp(rampRate);
+        } else {
+            master.configOpenloopRamp(0.0);
+        }
+
+    }
+
+    @Override
     public void setMasterMotorSafety(boolean enabled) {
         master.setSafetyEnabled(enabled);
 
@@ -232,8 +256,8 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
 
         // Build info string
         String data = String.format(
-                "Output: %.2f, Inverted %b, Current limited: %b, Voltage Compensation: %b, Current threshold: %.2f, Current hold: %.2f",
-                output, inverted, currentLimited, voltageCompEnabled, currentThresh, currentHold);
+                "Output: %.2f, Inverted %b, Current limited: %b, Voltage Compensation: %b, Current threshold: %.2f, Current hold: %.2f, Ramp rate: %.2f",
+                output, inverted, currentLimited, voltageCompEnabled, currentThresh, currentHold, rampRate);
 
         // Log string
         logger.log(name, data, Level.kInfo);
@@ -248,6 +272,7 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
         telemetryTable.getEntry("Voltage Compensation").setBoolean(voltageCompEnabled);
         telemetryTable.getEntry("Curent Threshold").setNumber(currentThresh);
         telemetryTable.getEntry("Current Hold").setNumber(currentHold);
+        telemetryTable.getEntry("Ramp Rate").setNumber(rampRate);
 
     }
 

--- a/src/main/java/frc/lib5k/components/motors/interfaces/IRampRateController.java
+++ b/src/main/java/frc/lib5k/components/motors/interfaces/IRampRateController.java
@@ -1,0 +1,29 @@
+package frc.lib5k.components.motors.interfaces;
+
+/**
+ * A common interface for devices with configurable output ramp rates
+ */
+public interface IRampRateController {
+
+    /**
+     * Set the controller ramp rate.
+     * 
+     * @param secondsToFull Minimum desired time to go from neutral to full output.
+     */
+    public void setRampRate(double secondsToFull);
+
+    /**
+     * Get the configured ramp rate
+     * 
+     * @return Configured rate in seconds
+     */
+    public double getRampRate();
+
+    /**
+     * Set if ramp rate limiting should be enabled for the controller
+     * 
+     * @param enabled Should enable limiting?
+     */
+    public void enableRampRateLimiting(boolean enabled);
+
+}

--- a/src/main/java/frc/lib5k/control/SlewLimiter.java
+++ b/src/main/java/frc/lib5k/control/SlewLimiter.java
@@ -51,4 +51,13 @@ public class SlewLimiter {
         limit = rate;
     }
 
+    /**
+     * Get the maximum amount of change allowed by the system
+     * 
+     * @return Maximum change
+     */
+    public double getRate() {
+        return limit;
+    }
+
 }

--- a/src/main/java/frc/lib5k/control/TimedSlewLimiter.java
+++ b/src/main/java/frc/lib5k/control/TimedSlewLimiter.java
@@ -1,0 +1,82 @@
+package frc.lib5k.control;
+
+import frc.lib5k.roborio.FPGAClock;
+
+/**
+ * An extension of SlewLimiter that acts a bit more like TalonSRX's rampRate
+ * setting, and respects non 20ms periods
+ */
+public class TimedSlewLimiter extends SlewLimiter {
+
+    /* Locals */
+    private boolean enabled;
+    private double lastTime;
+
+    /**
+     * Create a TimedSlewLimiter
+     * 
+     * @param secondsToFull Minimum desired time to go from neutral to full output
+     */
+    public TimedSlewLimiter(double secondsToFull) {
+        super(secondsToFull);
+    }
+
+    /**
+     * Set the ramp rate
+     * 
+     * @param secondsToFull Minimum desired time to go from neutral to full output
+     */
+    @Override
+    public void setRate(double secondsToFull) {
+        super.setRate(secondsToFull);
+    }
+
+    /**
+     * Enable or disable the system
+     * 
+     * @param enabled Should the system be enabled?
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+
+        if (!enabled) {
+            reset();
+        }
+    }
+
+    /**
+     * Limit a value, and update the system. NOTE: This will be much lower
+     * resolution than the TalonSRX built-in limiter, but we have yet to have
+     * problems with it.
+     * 
+     * @param value Input value
+     * @return Output value
+     */
+    @Override
+    public double feed(double value) {
+
+        // Simply return the value if the limiter is disabled or there is no ramp
+        if (!enabled || limit == 0.0) {
+            return value;
+        }
+
+        // Find dt
+        double dt = FPGAClock.getFPGASeconds() - lastTime;
+        lastTime = FPGAClock.getFPGASeconds();
+
+        // Determine allotted change for time step
+        double max_change = (1 / limit) * dt;
+
+        // Calculate slew
+        double error = value - output;
+        if (error > max_change) {
+            error = max_change;
+        } else if (error < (max_change * -1)) {
+            error = max_change * -1;
+        }
+        output += error;
+
+        return output;
+    }
+
+}


### PR DESCRIPTION

## Changes
 - Added `IRampRateController` interface for all controllers with ramp rate control
 -  `TimedSlewLimiter` extends `SlewLimiter` and provides TalonSRX-like ramp control
 -  `TalonSRXCollection`, `SparkCollection`, and `MixedMotorCollection` all now implement `IRampRateController`