### PR TITLE
Fixed robot not disabling brakes while disabled

### DIFF
--- a/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
+++ b/src/main/java/frc/lib5k/components/motors/TalonSRXCollection.java
@@ -2,6 +2,7 @@ package frc.lib5k.components.motors;
 
 import java.util.function.Consumer;
 
+import com.ctre.phoenix.motorcontrol.NeutralMode;
 import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 
 import edu.wpi.first.networktables.NetworkTable;
@@ -246,6 +247,18 @@ public class TalonSRXCollection extends SpeedControllerGroup implements IMotorCo
 
         // Otherwise, get the encoder from the list of slaves
         return new TalonEncoder(slaves[id]);
+    }
+
+    public void setNeutralMode(NeutralMode mode) {
+
+        // Set master mode
+        master.setNeutralMode(mode);
+
+        // Set slaves modes
+        forEachSlave((talon) -> {
+            talon.setNeutralMode(mode);
+        });
+
     }
 
     /**

--- a/src/main/java/frc/robot/subsystems/Drive.java
+++ b/src/main/java/frc/robot/subsystems/Drive.java
@@ -121,8 +121,8 @@ public class Drive extends Subsystem {
         if (m_isNewConfigData) {
 
             // Set brake mode for all talons
-            m_leftGearbox.getMaster().setNeutralMode(m_desiredBrakeMode);
-            m_rightGearbox.getMaster().setNeutralMode(m_desiredBrakeMode);
+            m_leftGearbox.setNeutralMode(m_desiredBrakeMode);
+            m_rightGearbox.setNeutralMode(m_desiredBrakeMode);
 
             // Data had been sent, disable lock
             m_isNewConfigData = false;
@@ -140,8 +140,6 @@ public class Drive extends Subsystem {
 
         // Output telemetry data
         outputTelemetry();
-
-        // System.out.println(String.format("L: %.2f | R: %.2f", m_leftGearbox.getEstimatedVoltage(), m_rightGearbox.getEstimatedVoltage()));
 
     }
 


### PR DESCRIPTION
MiniBot was having an issue where it was not coasting when disabled. Turns out, despite telling the slaves to follow their master, they do not actually pick up brake mode settings from the master controller. I just added a method to `TalonSRXCollection` that will set the mode for all controllers in a collection